### PR TITLE
Fixed support on Ubuntu Linux, brought back AllButtons interaction, finished WheelEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The source code is based on [Nicanor Romero Venier's project](https://github.com
 
 The code was tested using Python 3.6.6, PySide2 5.13.2 and VTK 8.1.1 (built with vtkRenderingExternal module in Release mode), VTK 8.1.2 (built without vtkRenderingExternal module in Debug mode), VTK 8.2.0 (built without vtkRenderingExternal module in Debug mode) in Windows 10.
 
-In [Nicanor's post](https://medium.com/bq-engineering/integrating-qtquickcontrols-2-with-vtk-df54bbb99de3), he claimed that "in order for this code to work you will need to add the vtkRenderingExternal module when compiling VTK". I'm not sure about this module but I also tested this porject with VTK 8.1.2 and VTK 8.2.0 which are built without vtkRenderingExternal module.
+The code was also tested in Ubuntu 18.04 Linux under [Miniconda](https://docs.conda.io/en/latest/miniconda.html) environment with Python 3.7.5, PySide2 5.13.1 (from conda-forge), qt 5.12.5 and VTK 8.2. 
+
+In [Nicanor's post](https://medium.com/bq-engineering/integrating-qtquickcontrols-2-with-vtk-df54bbb99de3), he claimed that "in order for this code to work you will need to add the vtkRenderingExternal module when compiling VTK". I'm not sure about this module but I also tested this porject with VTK 8.1.2 and VTK 8.2.0 which are built without vtkRenderingExternal module. When using libraries from the Miniconda distribution, the options are not required (or are simply already included).
 
 Anyway, thanks Nicanor very much!
 
@@ -17,6 +19,22 @@ Modify your qt.conf file (in python install folder) as below if needed:
 ```
 [Paths]
 Prefix = python-folder/Lib/site-packages/PySide2
+```
+
+## Miniconda setup
+
+You can start by creating a new conda environment with the following required packages:
+
+```sh
+conda create --name vtkqml python=3.7
+conda activate vtkqml
+conda install -c conda-forge qt vtk pyside2 numpy pandas pyopengl
+```
+
+Then, being in the root folder of the repository run the command:
+
+```sh
+python src/main.py
 ```
 
 ## Example

--- a/resources/main.qml
+++ b/resources/main.qml
@@ -25,21 +25,24 @@ ApplicationWindow {
             anchors.fill: parent
 
             MouseArea {
-                acceptedButtons: Qt.LeftButton
+                acceptedButtons: Qt.AllButtons
                 anchors.fill: parent
 
-                onPositionChanged: {
+                onPositionChanged: (mouse) => {
                     canvasHandler.mouseMoveEvent(pressedButtons, mouseX, mouseY);
+                    mouse.accepted = false
                 }
-                onPressed: {
+                onPressed: (mouse) => {
                     canvasHandler.mousePressEvent(pressedButtons, mouseX, mouseY);
                     // if u want to propagate the pressed event
                     // so the VtkFboItem instance can receive it
                     // then uncomment the belowed line
                     // mouse.ignore() // or mouse.accepted = false
+                    mouse.accepted = false
                 }
-                onReleased: {
+                onReleased: (mouse) => {
                     canvasHandler.mouseReleaseEvent(pressedButtons, mouseX, mouseY);
+                    mouse.accepted = false
                 }
             }
         }

--- a/src/CanvasHandler.py
+++ b/src/CanvasHandler.py
@@ -1,6 +1,7 @@
 from PySide2.QtCore import QObject, QUrl, qDebug, qCritical, Signal, Property, Slot
 from PySide2.QtQml import QQmlApplicationEngine, qmlRegisterType, QQmlEngine
 from PySide2.QtWidgets import QApplication
+from PySide2.QtGui import QSurfaceFormat
 
 from QVTKFramebufferObjectItem import FboItem
 from CommandModelTranslate import TranslateParams_t
@@ -21,6 +22,8 @@ class CanvasHandler(QObject):
         self.__m_vtkFboItem = None
         #* Set style: https://stackoverflow.com/questions/43093797/PySide2-quickcontrols-material-style
         sys_argv += ['--style', 'material'] #! MUST HAVE
+
+        QSurfaceFormat.setDefaultFormat(FboItem.defaultSurfaceFormat(False))
         app = QApplication(sys_argv)
 
         engine = QQmlApplicationEngine()
@@ -39,7 +42,7 @@ class CanvasHandler(QObject):
         ctxt.setContextProperty('canvasHandler', self)
 
         # #* Load main QML file
-        engine.load(QUrl.fromLocalFile('resources\\main.qml'))
+        engine.load(QUrl.fromLocalFile('resources/main.qml'))
 
         # #* Get reference to the QVTKFramebufferObjectItem in QML
         rootObject = engine.rootObjects()[0] # returns QObject

--- a/src/QVTKFramebufferObjectItem.py
+++ b/src/QVTKFramebufferObjectItem.py
@@ -39,8 +39,7 @@ class FboItem(QQuickFramebufferObject):
         self.__m_lastMouseLeftButton:QMouseEvent = QMouseEvent(QEvent.Type.None_, QPointF(0,0), Qt.NoButton, Qt.NoButton, Qt.NoModifier)
         self.__m_lastMouseButton:QMouseEvent = QMouseEvent(QEvent.Type.None_, QPointF(0,0), Qt.NoButton, Qt.NoButton, Qt.NoModifier)
         self.__m_lastMouseMove:QMouseEvent = QMouseEvent(QEvent.Type.None_, QPointF(0,0), Qt.NoButton, Qt.NoButton, Qt.NoModifier)
-        # self.__m_lastMouseWheel:QWheelEvent = QWheelEvent(QPointF(0,0), 0, Qt.NoButton, Qt.NoModifier, Qt.Vertical)
-        # self.__m_lastMouseWheel:QWheelEvent = QWheelEvent(QPointF(0,0), QPointF(0,0), QPoint(0,0), QPoint(0,0), 0, Qt.Vertical, Qt.NoButton, Qt.NoModifier)
+        self.__m_lastMouseWheel:QWheelEvent = None 
 
         self.setMirrorVertically(True) # QtQuick and OpenGL have opposite Y-Axis directions
         self.setAcceptedMouseButtons(Qt.AllButtons)
@@ -121,11 +120,11 @@ class FboItem(QQuickFramebufferObject):
 
     # #* Camera related functions
 
-    # def wheelEvent(self, e:QWheelEvent):
-    #     self.__m_lastMouseWheel = QWheelEvent(e)
-    #     self.__m_lastMouseWheel.ignore()
-    #     e.accept()
-    #     self.update()
+    def wheelEvent(self, e:QWheelEvent):
+        self.__m_lastMouseWheel = self.__cloneMouseWheelEvent(e)
+        self.__m_lastMouseWheel.ignore()
+        e.accept()
+        self.update()
 
     def mousePressEvent(self, e:QMouseEvent):
             self.__m_lastMouseButton = self.__cloneMouseEvent(e)
@@ -164,8 +163,8 @@ class FboItem(QQuickFramebufferObject):
         else:
             return self.__m_lastMouseMove
 
-    # def getLastWheelEvent(self) -> QWheelEvent:
-    #     return self.__m_lastMouseWheel
+    def getLastWheelEvent(self) -> QWheelEvent:
+        return self.__m_lastMouseWheel
 
 
     def resetCamera(self):
@@ -243,6 +242,20 @@ class FboItem(QQuickFramebufferObject):
         modifiers = e.modifiers()
         clone = QMouseEvent(event_type, local_pos, button, buttons, modifiers)
         clone.ignore()
+        return clone
+
+    def __cloneMouseWheelEvent(self, e:QWheelEvent):
+        pos = e.pos()
+        globalPos = e.globalPos() 
+        pixelDelta = e.pixelDelta() 
+        angleDelta = e.angleDelta()
+        buttons = e.buttons()
+        modifiers = e.modifiers()
+        phase = e.phase()
+        inverted = e.inverted()
+        clone = QWheelEvent(pos, globalPos, pixelDelta, angleDelta, buttons, modifiers, phase, inverted)
+        clone.ignore()
+        clone.accepted = False
         return clone
 
     def defaultSurfaceFormat(stereo_capable):

--- a/src/QVTKFramebufferObjectItem.py
+++ b/src/QVTKFramebufferObjectItem.py
@@ -43,7 +43,7 @@ class FboItem(QQuickFramebufferObject):
         # self.__m_lastMouseWheel:QWheelEvent = QWheelEvent(QPointF(0,0), QPointF(0,0), QPoint(0,0), QPoint(0,0), 0, Qt.Vertical, Qt.NoButton, Qt.NoModifier)
 
         self.setMirrorVertically(True) # QtQuick and OpenGL have opposite Y-Axis directions
-        self.setAcceptedMouseButtons(Qt.RightButton)
+        self.setAcceptedMouseButtons(Qt.AllButtons)
 
     def createRenderer(self):
         logging.debug('FboItem::createRenderer')
@@ -128,7 +128,6 @@ class FboItem(QQuickFramebufferObject):
     #     self.update()
 
     def mousePressEvent(self, e:QMouseEvent):
-        if e.buttons() & Qt.RightButton:
             self.__m_lastMouseButton = self.__cloneMouseEvent(e)
             self.__m_lastMouseButton.ignore()
             e.accept()
@@ -141,11 +140,10 @@ class FboItem(QQuickFramebufferObject):
         self.update()
 
     def mouseMoveEvent(self, e:QMouseEvent):
-        if e.buttons() & Qt.RightButton:
-            self.__m_lastMouseMove = self.__cloneMouseEvent(e)
-            self.__m_lastMouseMove.ignore()
-            e.accept()
-            self.update()
+        self.__m_lastMouseMove = self.__cloneMouseEvent(e)
+        self.__m_lastMouseMove.ignore()
+        e.accept()
+        self.update()
 
 
     def getLastMouseLeftButton(self, clone=True) -> QMouseEvent:

--- a/src/QVTKFramebufferObjectItem.py
+++ b/src/QVTKFramebufferObjectItem.py
@@ -1,5 +1,5 @@
 from PySide2.QtCore import QObject, QUrl, qDebug, qCritical, QEvent, QPoint, QPointF, Qt, Signal
-from PySide2.QtGui import QColor, QMouseEvent, QWheelEvent
+from PySide2.QtGui import QColor, QMouseEvent, QWheelEvent, QSurfaceFormat
 from PySide2.QtQuick import QQuickFramebufferObject
 
 from CommandModelAdd import CommandModel
@@ -246,3 +246,22 @@ class FboItem(QQuickFramebufferObject):
         clone = QMouseEvent(event_type, local_pos, button, buttons, modifiers)
         clone.ignore()
         return clone
+
+    def defaultSurfaceFormat(stereo_capable):
+        """ Ported from: https://github.com/Kitware/VTK/blob/master/GUISupport/Qt/QVTKRenderWindowAdapter.cxx
+        """
+        fmt = QSurfaceFormat()
+        fmt.setRenderableType(QSurfaceFormat.OpenGL)
+        fmt.setVersion(3, 2)
+        fmt.setProfile(QSurfaceFormat.CoreProfile)
+        fmt.setSwapBehavior(QSurfaceFormat.DoubleBuffer)
+        fmt.setRedBufferSize(8)
+        fmt.setGreenBufferSize(8)
+        fmt.setBlueBufferSize(8)
+        fmt.setDepthBufferSize(8)
+        fmt.setAlphaBufferSize(8)
+        fmt.setStencilBufferSize(0)
+        fmt.setStereo(stereo_capable)
+        fmt.setSamples(0)
+
+        return fmt

--- a/src/QVTKFramebufferObjectRenderer.py
+++ b/src/QVTKFramebufferObjectRenderer.py
@@ -159,7 +159,7 @@ class RendererHelper(QObject):
             self.__m_firstRender = False
 
         #* Process camera related commands
-
+        
         #* Process mouse event
         if self.__m_mouseEvent and not self.__m_mouseEvent.isAccepted():
             self.__m_vtkRenderWindowInteractor.SetEventInformationFlipY(
@@ -180,7 +180,7 @@ class RendererHelper(QObject):
 
         #* Process move event
         if self.__m_moveEvent and not self.__m_moveEvent.isAccepted():
-            if self.__m_moveEvent.type() == QEvent.MouseMove and self.__m_moveEvent.buttons() & Qt.RightButton:
+            if self.__m_moveEvent.type() == QEvent.MouseMove and self.__m_moveEvent.buttons():
                 self.__m_vtkRenderWindowInteractor.SetEventInformationFlipY(
                     self.__m_moveEvent.x(),
                     self.__m_moveEvent.y(),

--- a/src/QVTKFramebufferObjectRenderer.py
+++ b/src/QVTKFramebufferObjectRenderer.py
@@ -51,7 +51,7 @@ class RendererHelper(QObject):
         self.__m_mouseLeftButton:QMouseEvent = None
         self.__m_mouseEvent:QMouseEvent = None
         self.__m_moveEvent:QMouseEvent = None
-        # self.__m_wheelEvent:QWheelEvent = None
+        self.__m_wheelEvent:QWheelEvent = None
 
         self.__m_platformModel:vtk.vtkCubeSource = None
         self.__m_platformGrid:vtk.vtkPolyData = None
@@ -139,9 +139,8 @@ class RendererHelper(QObject):
             self.__m_moveEvent = self.__m_vtkFboItem.getLastMoveEvent()
             self.__m_vtkFboItem.getLastMoveEvent(clone=False).accept()
 
-        # if not self.__m_vtkFboItem.getLastWheelEvent().isAccepted():
-        #     self.__m_wheelEvent = self.__m_vtkFboItem.getLastWheelEvent()
-        #     self.__m_vtkFboItem.getLastWheelEvent().accept()
+        if self.__m_vtkFboItem.getLastWheelEvent() and not self.__m_vtkFboItem.getLastWheelEvent().isAccepted():
+            self.__m_wheelEvent = self.__m_vtkFboItem.getLastWheelEvent()
 
         #* Get extra data
         self.__m_modelsRepresentationOption = self.__m_vtkFboItem.getModelsRepresentation()
@@ -194,14 +193,22 @@ class RendererHelper(QObject):
 
             self.__m_moveEvent.accept()
 
-        # #* Process wheel event
-        # if self.__m_wheelEvent and not self.__m_wheelEvent.isAccepted():
-        #     if self.__m_wheelEvent.delta() > 0:
-        #         self.__m_vtkRenderWindowInteractor.InvokeEvent(vtk.vtkCommand.MouseWheelForwardEvent, self.__m_wheelEvent)
-        #     elif self.__m_wheelEvent.delta() < 0:
-        #         self.__m_vtkRenderWindowInteractor.InvokeEvent(vtk.vtkCommand.MouseWheelBackwardEvent, self.__m_wheelEvent)
+        #* Process wheel event
+        if self.__m_wheelEvent and not self.__m_wheelEvent.isAccepted():
+            self.__m_vtkRenderWindowInteractor.SetEventInformationFlipY(
+                self.__m_wheelEvent.x(), self.__m_wheelEvent.y(),
+                1 if (self.__m_wheelEvent.modifiers() & Qt.ControlModifier) > 0 else 0,
+                1 if (self.__m_wheelEvent.modifiers() & Qt.ShiftModifier) > 0 else 0,
+                '0',
+                1 if self.__m_wheelEvent.type() == QEvent.MouseButtonDblClick else 0
+            )
 
-        #     self.__m_wheelEvent.accept()
+            if self.__m_wheelEvent.delta() > 0:
+                self.__m_vtkRenderWindowInteractor.InvokeEvent(vtk.vtkCommand.MouseWheelForwardEvent)
+            elif self.__m_wheelEvent.delta() < 0:
+                self.__m_vtkRenderWindowInteractor.InvokeEvent(vtk.vtkCommand.MouseWheelBackwardEvent)
+
+            self.__m_wheelEvent.accept()
 
         #* Process model related commands
 

--- a/src/QVTKFramebufferObjectRenderer.py
+++ b/src/QVTKFramebufferObjectRenderer.py
@@ -11,21 +11,6 @@ import logging
 from OpenGL import GL
 
 
-#* https://github.com/Kitware/VTK/blob/master/GUISupport/Qt/QVTKOpenGLNativeWidget.cxx
-fmt = QSurfaceFormat()
-fmt.setRenderableType(QSurfaceFormat.OpenGL)
-fmt.setVersion(3, 2)
-fmt.setProfile(QSurfaceFormat.CoreProfile)
-fmt.setSwapBehavior(QSurfaceFormat.DoubleBuffer)
-fmt.setRedBufferSize(8)
-fmt.setGreenBufferSize(8)
-fmt.setBlueBufferSize(8)
-fmt.setDepthBufferSize(8)
-fmt.setAlphaBufferSize(8)
-fmt.setStencilBufferSize(0)
-fmt.setStereo(True)
-fmt.setSamples(0) # we never need multisampling in the context since the FBO can support multisamples independently
-
 class FboRenderer(QQuickFramebufferObject.Renderer):
     def __init__(self):
         super().__init__()

--- a/src/QVTKFramebufferObjectRenderer.py
+++ b/src/QVTKFramebufferObjectRenderer.py
@@ -300,6 +300,8 @@ class RendererHelper(QObject):
         axes_length = 20.0
         axes_label_font_size = np.int16(20)
         axes.SetTotalLength(axes_length, axes_length, axes_length)
+        axes.SetCylinderRadius(0.02)
+        axes.SetShaftTypeToCylinder()
         axes.GetXAxisCaptionActor2D().GetTextActor().SetTextScaleModeToNone()
         axes.GetYAxisCaptionActor2D().GetTextActor().SetTextScaleModeToNone()
         axes.GetZAxisCaptionActor2D().GetTextActor().SetTextScaleModeToNone()


### PR DESCRIPTION
First, thank you very much for your work on porting original C++ version to PySide2. Your work was a great help for me when I was implementing QML+VTK with PySide2 integration.

Just to give something back :-), I have implemented some hacks that were required to successfully run the code on Ubuntu 18.04 Linux. The main problem was that the QSurfaceFormat must be run before creating the QApplication object. I have moved your code configuring the QSurfaceFormat to a separate static function in FboItem class and run from the CanvasHandler constructor.

I also think, that the mouse interaction should more conform to the VTK style and I have brought back the support for the LeftMouse button for rotating, translation and zooming.  

I have also finished the implementation for WheelEvent.

Last but not least, I have updated the information in README about the tested platforms and have written short guide on the installation under Miniconda environment.

Hope You will find my contributions usefull :-)

Best regards,
Robert Szmurlo